### PR TITLE
fix compat with sahil2801/replit-code-instruct-glaive

### DIFF
--- a/scripts/chat_play.py
+++ b/scripts/chat_play.py
@@ -181,6 +181,7 @@ def main():
 
   tokenizer: AutoTokenizer = AutoTokenizer.from_pretrained(
     model_args.model_name_or_path,
+    trust_remote_code=model_args.trust_remote_code,
     cache_dir=None,
     padding_side="right",
     use_fast=True,

--- a/scripts/chat_play.py
+++ b/scripts/chat_play.py
@@ -209,7 +209,7 @@ def main():
   while True:
     try:
       user_input = input(f'{blue_ansi}Type a message to begin the conversation…{reset_ansi}\n{prompt}' if first else prompt)
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, EOFError):
       sys.exit(0)
     print(reset_ansi, end='')
 


### PR DESCRIPTION
fixes this error:

```
$ PYTORCH_ENABLE_MPS_FALLBACK=1 python3.10 -m scripts.chat_play --trust_remote_code --model_name_or_path sahil2801/replit-code-instruct-glaive
ValueError: Loading sahil2801/replit-code-instruct-glaive requires you to execute the tokenizer file in that repo on your local machine. Make sure you have read the code there to avoid malicious use, then set the option `trust_remote_code=True` to remove this error.
```